### PR TITLE
allow to specify google cloud project for proper displaying of logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class Logger {
             auth.resource = auth.resource || {
                 type: 'project',
                 labels: {
-                    project_id: appParams.name,
+                    project_id: process.env.GCLOUD_PROJECT || appParams.name,
                 },
             };
         }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "1.4.0",
+  "version": "1.5.0",
   "jest": {
     "bail": true,
     "collectCoverage": true


### PR DESCRIPTION
this should allow to see logs filtered by a service in the basic filter mode in the stackdriver console