### PR TITLE
TE-1346 logging levels

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,9 @@ class Logger {
         module.addStream(this.createRemoteStream(level, this.defaults.remoteAuth, this.defaults.appParams));
         module.streams[module.streams.length - 1].level = newLevel;
       }
+      let minLevel = bunyan.levelFromName['fatal'];
+      module.streams.forEach(s => minLevel = s.level < minLevel ? s.level : minLevel);
+      module._level = minLevel;
     } else {
       module.level(newLevel);
     }

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ module.exports = (options) => {
 
 class Logger {
   constructor(appParams, localLevel, remoteLevel, remoteAuth) {
-    this.modules = [];
     this.streams = {};
     this.defaults = {
       appParams,
@@ -23,7 +22,8 @@ class Logger {
       remoteLevel,
       remoteAuth,
     };
-    this.logger = this.createLogger(appParams, localLevel, remoteLevel, remoteAuth);
+    this.logger = this.createLogger(appParams, localLevel, remoteLevel, remoteAuth, 'main');
+    this.modules = [this.logger];
   }
 
   createLogger(appParams, localLevel, remoteLevel, remoteAuth, name) {
@@ -41,6 +41,10 @@ class Logger {
 
     ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(logMethod => myLoggerMethod(logger, logMethod));
     logger.module = (moduleName) => {
+      const module = this.modules.find(m => m.fields.module === moduleName);
+      if (module) {
+        return module;
+      }
       const moduleLogger = this.createLogger(appParams, localLevel, remoteLevel, remoteAuth, moduleName);
       this.modules.push(moduleLogger);
       moduleLogger.levels = (level, module, stream) => this.levels(level, module || moduleName, stream);

--- a/index.js
+++ b/index.js
@@ -1,70 +1,184 @@
 const bunyan = require('bunyan');
 
 module.exports = (options) => {
-    if (!options) options = {};
+  if (!options) options = {};
 
-    if (typeof options.app === 'undefined') options.app = {name: options.app_name};
-    if (typeof options.app.name === 'undefined') options.app.name = 'app';
-    if (typeof options.local_level === 'undefined') options.local_level = process.env.LOG_LEVEL_LOCAL;
-    if (typeof options.remote_level === 'undefined') options.remote_level = process.env.LOG_LEVEL_REMOTE;
+  if (typeof options.app === 'undefined') options.app = {name: options.app_name};
+  if (typeof options.app.name === 'undefined') options.app.name = 'app';
+  if (typeof options.local_level === 'undefined') options.local_level = process.env.LOG_LEVEL_LOCAL;
+  if (typeof options.remote_level === 'undefined') options.remote_level = process.env.LOG_LEVEL_REMOTE;
 
-    const logger = new Logger(options.app, options.local_level, options.remote_level, options.remote_auth);
+  const logger = new Logger(options.app, options.local_level, options.remote_level, options.remote_auth);
 
-    return logger.logger;
+  return logger.logger;
 };
 
 class Logger {
-    constructor(appParams, localLevel, remoteLevel, remoteAuth) {
-        this.streams = [];
+  constructor(appParams, localLevel, remoteLevel, remoteAuth) {
+    this.modules = [];
+    this.defaults = {
+      appParams,
+      localLevel,
+      remoteLevel,
+      remoteAuth,
+    };
+    this.logger = this.createLogger(appParams, localLevel, remoteLevel, remoteAuth);
+  }
 
-        let options = {};
-        if (localLevel) {
-            this.addLocalStream(localLevel);
+  createLogger(appParams, localLevel, remoteLevel, remoteAuth, name) {
+    const options = {
+      name: appParams.name,
+      streams: this.createStreams(appParams, localLevel, remoteLevel, remoteAuth),
+    };
+    if (name) {
+      options.module = name;
+    }
+    const logger = bunyan.createLogger(options);
+    logger.log = myLoggerMethod(logger, 'info');
+
+    ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(logMethod => myLoggerMethod(logger, logMethod));
+    logger.module = (moduleName) => {
+      const moduleLogger = this.createLogger(appParams, localLevel, remoteLevel, remoteAuth, moduleName);
+      this.modules.push(moduleLogger);
+      return moduleLogger;
+    };
+    logger.setLevels = logger.levels; // original bunyan method
+    logger.levels = (level, module, stream) => this.levels(level, module, stream);
+    return logger;
+  }
+
+  levels(level, moduleName, streamName) {
+    if (level !== undefined) {
+      if (moduleName) {
+        const module = this.modules.find(m => m.fields.module === moduleName);
+        if (module) {
+          this.updateStream(level, module, streamName);
         }
+      } else {
+        this.modules.forEach(m => this.levels(level, m.fields.module, streamName));
+      }
+    }
+    return this.getLevels();
+  }
 
-        if (remoteLevel) {
-            this.addRemoteStream(remoteLevel, remoteAuth, appParams);
-            Object.assign(options, {
-                serviceContext: {
-                    service: appParams.name,
-                    version: appParams.version,
-                }});
+  updateStream(level, module, streamName) {
+    let newLevel;
+    try {
+      newLevel = bunyan.resolveLevel(level);
+    } catch(e) {
+      newLevel = bunyan.resolveLevel('info');
+    }
+    if (streamName) {
+      const streamIndex = module.streams.findIndex(s => s.name === streamName);
+      if (streamIndex >= 0) {
+        if (!level) {
+          module.streams.splice(streamIndex, 1);
+        } else {
+          module.streams[streamIndex].level = newLevel;
         }
+      } else if (streamName === 'stdout' && level) {
+        module.addStream(this.createLocalStream(level));
+      } else if (streamName === 'gcloud' && level) {
+        module.addStream(this.createRemoteStream(level, this.defaults.remoteAuth, this.defaults.appParams));
+      }
+    } else {
+      module.level(newLevel);
+    }
+  }
 
-        Object.assign(options, {
-            name: appParams.name,
-            streams: this.streams
-        });
-        this.logger = bunyan.createLogger(options);
+  getLevels() {
+    const toLevels = logger => {
+      const streamLevels = {};
+      logger.streams.forEach(s => streamLevels[s.name] = bunyan.nameFromLevel[s.level]);
+      return streamLevels;
+    };
+    const levels = {
+      main: toLevels(this.logger),
+    };
+    this.modules.forEach(m => levels[m.fields.module] = toLevels(m));
+    return levels;
+  }
 
-        this.logger.module = (moduleName) => {
-            return bunyan.createLogger(Object.assign({}, options, {module: moduleName}));
-        };
+  createStreams(appParams, localLevel, remoteLevel, remoteAuth) {
+    const streams = [];
+    if (localLevel) {
+      streams.push(this.createLocalStream(localLevel));
     }
 
-    addLocalStream(level) {
-        const PrettyStream = require('bunyan-prettystream-circularsafe');
-        let stream = new PrettyStream();
-        stream.pipe(process.stdout);
-        this.streams.push({
-            type: 'raw',
-            stream: stream,
-            level: level,
-        });
+    if (remoteLevel) {
+      streams.push(this.createRemoteStream(remoteLevel, remoteAuth, appParams));
     }
+    return streams;
+  }
 
-    addRemoteStream(level, auth, appParams) {
-        if (auth) {
-            auth.logName = auth.logName || appParams.name;
-            auth.resource = auth.resource || {
-                type: 'project',
-                labels: {
-                    project_id: process.env.GCLOUD_PROJECT || appParams.name,
-                },
-            };
-        }
-        const loggingBunyan = require('@google-cloud/logging-bunyan')(auth);
-        let stream = loggingBunyan.stream(level);
-        this.streams.push(stream);
+  createLocalStream(level) {
+    const PrettyStream = require('bunyan-prettystream-circularsafe');
+    const stream = new PrettyStream();
+    stream.pipe(process.stdout);
+    return {
+      type: 'raw',
+      stream: stream,
+      level: level,
+      name: 'stdout',
+    };
+  }
+
+  createRemoteStream(level, auth, appParams) {
+    const options = {
+      logName: appParams.name,
+      serviceContext: {
+        service: appParams.name,
+        version: appParams.version,
+      },
+    };
+    if (auth) {
+      Object.assign(options, auth);
+      options.resource = auth.resource || {
+        type: 'project',
+        labels: {
+          project_id: process.env.GCLOUD_PROJECT || appParams.name,
+          container_name: process.env.CONTAINER_NAME,
+        },
+      };
     }
+    const { LoggingBunyan } = require('@google-cloud/logging-bunyan');
+    const loggingBunyan = new LoggingBunyan(options);
+    const stream = loggingBunyan.stream(level);
+    stream.name = 'gcloud';
+    return stream;
+  }
+}
+
+/**
+ * Override original logging methods to add functionality
+ * 1) Call function arguments to get data (rather than logging 'Function')
+ *    - shorthand for if (logger.level() < logger.TRACE) ...
+ * 2) Bunyan has special handling for error objects, but they need to be the first arg, so move if necessary
+ *
+ */
+function myLoggerMethod(logger, levelName) {
+  const minLevel = bunyan.levelFromName[levelName];
+  const original = logger[levelName];
+  logger[levelName] = function() {
+    let msgArgs = arguments;
+    if (logger._level <= minLevel) {
+      for (let i = 0; i < msgArgs.length; i++) {
+        const arg = msgArgs[i];
+        // call function arguments to get data (rather than logging 'Function')
+        if (typeof arg === 'function') {
+          try {
+            msgArgs[i] = arg();
+          } catch(e) {}
+        }
+
+        // Bunyan has special handling for error objects - but they need to be the first arg. So move if necessary...
+        if (i > 0 && arg instanceof Error && !(msgArgs[0] instanceof Error)) {
+          msgArgs = Array.from(msgArgs);
+          msgArgs.splice(i, 1);
+          msgArgs.unshift(arg);
+        }
+      }
+    }
+    original.apply(logger, arguments);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/betastreet/bunyan-buddy/issues"
   },
   "dependencies": {
-    "bunyan": "^1.9.0",
+    "bunyan": "^1.8.12",
     "bunyan-prettystream-circularsafe": "https://github.com/betastreet/node-bunyan-prettystream/archive/master.tar.gz",
     "@google-cloud/logging": "^4.0.1",
     "@google-cloud/logging-bunyan": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -40,5 +40,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "1.5.1"
+  "version": "1.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -7,15 +7,13 @@
     "url": "https://github.com/betastreet/bunyan-buddy/issues"
   },
   "dependencies": {
-    "bunyan": "^1.8.12",
+    "bunyan": "^1.9.0",
     "bunyan-prettystream-circularsafe": "https://github.com/betastreet/node-bunyan-prettystream/archive/master.tar.gz",
-    "@google-cloud/logging": "1.0.6",
-    "@google-cloud/logging-bunyan": "^0.6.0"
+    "@google-cloud/logging": "^4.0.1",
+    "@google-cloud/logging-bunyan": "^0.9.1"
   },
   "description": "Reduce the amount of Bunyan boilerplate code required, ideal when working with microservices.",
-  "devDependencies": {
-    "jest": "^20.0.4"
-  },
+  "devDependencies": {},
   "directories": {},
   "homepage": "https://github.com/betastreet/bunyan-buddy#readme",
   "keywords": [
@@ -42,9 +40,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "1.5.1",
-  "jest": {
-    "bail": true,
-    "collectCoverage": true
-  }
+  "version": "1.5.1"
 }


### PR DESCRIPTION
TE-1346: Modify logging on the fly
- Changed logger to create new streams for each module so that the levels could be set independently
- levels() method will now update the logging level on any module/stream by request. It will add/remove streams if the level is empty
- levels() will set all modules/streams to the level if not specified
- levels() will return existing levels for all modules/streams as an object of objects
- update bunyan and @google-cloud/logging

TE-1005: Log with function pointers
- override existing logging methods to do some pre-work:
-- call function arguments to get return value
-- move error objects to first argument